### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,5 +18,5 @@ dependencies {
 repositories {
     mavenLocal()
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo( "dev" )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf = "2.1.1"
-util = "3.1.1"
+util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Bumps Enonic libs to next-major SNAPSHOTs published from each lib's master after the XP 8 upgrade. This repo only consumes one of the libs in scope (`lib-util`); the others (`lib-menu`, `lib-explorer`) are not used here.

| Lib | Before | After | Notes |
| --- | --- | --- | --- |
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT` | next-major SNAPSHOT from `enonic/lib-util` master, resolves from the Enonic dev/snapshot repo |

The pin is a SNAPSHOT and resolves from the Enonic dev/snapshot Maven repo. The repositories block previously declared `xp.enonicRepo()` (release-only); changed to `xp.enonicRepo( "dev" )` so SNAPSHOTs resolve. `mavenLocal()` and `mavenCentral()` are unchanged.

## Excludes

The repo had no `exclude` clauses on any dependency before this change, so there was nothing to remove or re-evaluate.

## Verification

- `./gradlew clean build` — green locally
- `./gradlew dependencies --configuration include` — confirms `com.enonic.lib:lib-util:4.0.0-SNAPSHOT` resolves
- Runtime verification (deploying the app into a running XP 8 server) was **not** performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)