### PR TITLE
Bump version to 4.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = poll
 appName = com.enonic.app.poll
 xpVersion = 8.0.0-B4
-version = 3.1.0-SNAPSHOT
+version = 4.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bumps `version` in `gradle.properties` from `3.1.0-SNAPSHOT` to `4.0.0-SNAPSHOT` for the XP 8 line on master.
- Adds `releaseBranch:` block to the `build-and-publish` action listing both `master` and `3.x`, so pushes to either branch are recognized as release-branch builds.

The XP 7 maintenance line continues on the new `3.x` branch (created at the post-release SNAPSHOT commit `2bc3be9`, which carries `version=3.1.0-SNAPSHOT`).

## Test plan

- [ ] CI green on this branch
- [ ] After merge: confirm `./gradlew clean build` from master is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)