### PR TITLE
Add release-branch CI config for 3.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/enonic-gradle.yml` to the `3.x` maintenance branch.
- The workflow uses the modern `enonic/release-tools/build-and-publish@master` + `release@master` actions and declares both `master` and `3.x` under `releaseBranch:` so pushes to `3.x` are recognized as release-branch builds.
- No version bump and no other changes — the `3.x` branch stays on `xpVersion=7.0.0` / `version=3.1.0-SNAPSHOT`. The major bump and master-only file changes live in #50 against `master`.

## Test plan

- [ ] CI green on this branch
- [ ] After merge: a CI run on `3.x` is classified as a release branch (i.e. `build-and-publish` outputs `release=true` for tagged release commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)