### PR TITLE
Fix poll part runtime on XP 8 #52

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-thymeleaf = "2.1.1"
+thymeleaf = "3.0.0-SNAPSHOT"
 util = "4.0.0-SNAPSHOT"
 
 [libraries]

--- a/src/main/resources/cms/parts/poll/poll.js
+++ b/src/main/resources/cms/parts/poll/poll.js
@@ -4,8 +4,8 @@ var auth = require('/lib/xp/auth'),
     contextLib = require('/lib/xp/context'),
     portal = require('/lib/xp/portal'),
     thymeleaf = require('/lib/thymeleaf'),
-    util = require('/lib/util'),
-    moment = require('/assets/momentjs/2.24.0/min/moment-with-locales.min.js');
+    util = require('/lib/util/data'),
+    moment = require('/assets/momentjs/2.30.1-1/moment-with-locales.min.js');
 
 exports.get = handleGet;
 exports.post = handlePost;
@@ -23,7 +23,7 @@ function handleGet(req) {
         var body = thymeleaf.render( resolve('poll.html'), createModel() ),
             pageContributions = {
                 headEnd: [
-                    '<script src="' + portal.assetUrl({path: 'jquery/3.4.1/jquery.min.js'}) + '"></script>',
+                    '<script src="' + portal.assetUrl({path: 'jquery/4.0.0/jquery.min.js'}) + '"></script>',
                     '<script>var $j = jQuery.noConflict(true);</script>'],
                 bodyEnd: ['<script src="' + portal.assetUrl({path: 'js/polls.js'}) + '"></script>']
             };
@@ -65,7 +65,7 @@ function handleGet(req) {
         model.expires = getExpires(closed, poll.data.expires);
         model.closed = closed || hasResponded(poll, req.cookies);
         model.total = results ? results.total + ' vote(s)' : '0 votes';
-        model.options = getResultCount(results, util.data.forceArray(poll.data.options), model.closed);
+        model.options = getResultCount(results, util.forceArray(poll.data.options), model.closed);
         model.requireLogin = poll.data.requireLogin && !user;
 
         return model;
@@ -89,7 +89,7 @@ function handlePost(req) {
     if(!pollContent) {
         return error('No poll content.');
     }
-    var pollOptions = util.data.forceArray(pollContent.data.options); // Array of the options
+    var pollOptions = util.forceArray(pollContent.data.options); // Array of the options
 
     if(!isValidOption(params.option, pollOptions)) {
         return error('Not a valid option ' + params.option);


### PR DESCRIPTION
Closes #52

## What

Verifying app-poll against XP 8 (`xpVersion=8.0.0-B4`, the value declared in `gradle.properties`) surfaced three runtime breakages and one missing lib bump. None of them showed up in the build — they only fire the first time the part is loaded or the page is rendered. Patched all four here.

### 1. `require('/lib/util')` fails on XP 8

`lib-util` 4.0.0-SNAPSHOT's `/lib/util/index.es` eagerly imports `./portal/getLocale`, which destructures `getLocale` out of `/lib/xp/admin`. In XP 8 the admin lib no longer exports `getLocale`, so resolving `/lib/util` throws `Resource [com.enonic.app.poll:/lib/xp/admin] was not found` the first time `poll.js` is loaded.

Switched the controller to `require('/lib/util/data')` (which has no admin dependency) and updated the two `util.data.forceArray(...)` call sites to `util.forceArray(...)`.

### 2. momentjs path is stale

Dependabot bumped the webjar (`org.webjars:momentjs` 2.30.1 → 2.30.1-1, before that `2.24.0` → 2.30.1) but the controller `require` was never updated. Old path:

    /assets/momentjs/2.24.0/min/moment-with-locales.min.js

In webjar 2.30.x the version directory changed and the `min/` subdir was dropped, so the new resource is just:

    /assets/momentjs/2.30.1-1/moment-with-locales.min.js

### 3. jQuery page-contribution path is stale

Same story for jQuery: webjar was bumped to 4.0.0 (PR #44) but the page contribution still points at `jquery/3.4.1/jquery.min.js`, which 404s. Updated to `jquery/4.0.0/jquery.min.js`.

### 4. `lib-thymeleaf` bump

Per the XP 8 lib sweep, bumped `lib-thymeleaf` `2.1.1` → `3.0.0-SNAPSHOT` (lives on `repo.enonic.com/dev`, already wired up in `build.gradle`).

## How verified

Inside `claude-dev`, bootstrapped XP 8.0.0-B4 from `xp-distro` in `/tmp/xp-e2e-*`, deployed the patched `poll.jar`, then deployed a one-file probe webapp that runs the exact same top-level `require(...)` chain the part does. Before the fix, requiring `/lib/util` returned `FAILED: Resource [.../lib/xp/admin] was not found`; with the fix, all four imports load and `util.forceArray`, `moment`, and `thymeleaf.render` are callable. Bundle reaches `ACTIVE`, no `ERROR`/`Exception` in `server.log`, and `/_/asset/com.enonic.app.poll/{css,js,jquery/4.0.0/jquery.min.js}` all return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)