### PR TITLE
Drop lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     include xplibs.auth
     include xplibs.context
     include libs.lib.thymeleaf
-    include libs.lib.util
     webjar "org.webjars:jquery:4.0.0"
     webjar "org.webjars:momentjs:2.30.1-1"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,5 @@
 [versions]
 thymeleaf = "2.1.1"
-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
-lib-util = { module = "com.enonic.lib:lib-util", version.ref = "util" }

--- a/src/main/resources/cms/parts/poll/poll.js
+++ b/src/main/resources/cms/parts/poll/poll.js
@@ -4,7 +4,6 @@ var auth = require('/lib/xp/auth'),
     contextLib = require('/lib/xp/context'),
     portal = require('/lib/xp/portal'),
     thymeleaf = require('/lib/thymeleaf'),
-    util = require('/lib/util'),
     moment = require('/assets/momentjs/2.24.0/min/moment-with-locales.min.js');
 
 exports.get = handleGet;
@@ -65,7 +64,7 @@ function handleGet(req) {
         model.expires = getExpires(closed, poll.data.expires);
         model.closed = closed || hasResponded(poll, req.cookies);
         model.total = results ? results.total + ' vote(s)' : '0 votes';
-        model.options = getResultCount(results, util.data.forceArray(poll.data.options), model.closed);
+        model.options = getResultCount(results, (Array.isArray(poll.data.options) ? poll.data.options : [poll.data.options]), model.closed);
         model.requireLogin = poll.data.requireLogin && !user;
 
         return model;
@@ -89,7 +88,7 @@ function handlePost(req) {
     if(!pollContent) {
         return error('No poll content.');
     }
-    var pollOptions = util.data.forceArray(pollContent.data.options); // Array of the options
+    var pollOptions = Array.isArray(pollContent.data.options) ? pollContent.data.options : [pollContent.data.options]; // Array of the options
 
     if(!isValidOption(params.option, pollOptions)) {
         return error('Not a valid option ' + params.option);


### PR DESCRIPTION
## Summary

Removes the `lib-util` dependency from this app. The only call site was `util.data.forceArray(x)` in `cms/parts/poll/poll.js` (two occurrences), inlined as `(Array.isArray(x) ? x : [x])` (Nashorn-safe). No new helper module introduced.

## Changes

- `src/main/resources/cms/parts/poll/poll.js`: drop the `require('/lib/util')` binding; replace the two `util.data.forceArray(...)` calls with the inline `Array.isArray` ternary.
- `build.gradle`: drop `include libs.lib.util`.
- `gradle/libs.versions.toml`: drop the `util` version and `lib-util` library entries.

## Test plan

- [x] `./gradlew build` passes locally.
- [x] Built jar no longer bundles `com.enonic.lib.lib-util`.
- [ ] Manual smoke (deploy in XP, render a poll with a single option to confirm the `forceArray` path still wraps a non-array correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)