### PR TITLE
Migrate to lib-asset #55

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     include xplibs.auth
     include xplibs.context
     include libs.lib.thymeleaf
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
     webjar "org.webjars:jquery:4.0.0"
     webjar "org.webjars:momentjs:2.30.1-1"
 }

--- a/src/main/resources/cms/parts/poll/poll.js
+++ b/src/main/resources/cms/parts/poll/poll.js
@@ -3,6 +3,7 @@ var auth = require('/lib/xp/auth'),
     contentLib = require('/lib/xp/content'),
     contextLib = require('/lib/xp/context'),
     portal = require('/lib/xp/portal'),
+    assetLib = require('/lib/enonic/asset'),
     thymeleaf = require('/lib/thymeleaf'),
     moment = require('/assets/momentjs/2.30.1-1/moment-with-locales.min.js');
 
@@ -22,16 +23,16 @@ function handleGet(req) {
         var body = thymeleaf.render( resolve('poll.html'), createModel() ),
             pageContributions = {
                 headEnd: [
-                    '<script src="' + portal.assetUrl({path: 'jquery/4.0.0/jquery.min.js'}) + '"></script>',
+                    '<script src="' + assetLib.assetUrl({path: 'jquery/4.0.0/jquery.min.js'}) + '"></script>',
                     '<script>var $j = jQuery.noConflict(true);</script>'],
-                bodyEnd: ['<script src="' + portal.assetUrl({path: 'js/polls.js'}) + '"></script>']
+                bodyEnd: ['<script src="' + assetLib.assetUrl({path: 'js/polls.js'}) + '"></script>']
             };
 
         if(pollCSS == 'default') {
-            pageContributions.headEnd.push('<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/polls.css'}) + '" type="text/css" media="all">');
+            pageContributions.headEnd.push('<link rel="stylesheet" href="' + assetLib.assetUrl({path: 'css/polls.css'}) + '" type="text/css" media="all">');
         }
         if(pollCSS == 'bootstrap') {
-            pageContributions.headEnd.push('<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/poll-bootstrap.css'}) + '" type="text/css" media="all">');
+            pageContributions.headEnd.push('<link rel="stylesheet" href="' + assetLib.assetUrl({path: 'css/poll-bootstrap.css'}) + '" type="text/css" media="all">');
         }
 
         return {

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -1,1 +1,3 @@
 kind: "Site"
+apis:
+  - "asset"


### PR DESCRIPTION
`portal.assetUrl` is `@deprecated` in lib-portal — switching this app to **lib-asset** (`/lib/enonic/asset`). All four call sites live in a Site context, so lib-asset is the correct target (the docs warn against using it for Admin Extensions, ID Providers, or Universal APIs, none of which apply here).

## Changes

- **`build.gradle`** — add `include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"` (current XP 8 line per lib-asset `master`).
- **`src/main/resources/cms/site.yaml`** — register the Universal API: `apis: ["asset"]`.
- **`src/main/resources/cms/parts/poll/poll.js`** — import `var assetLib = require('/lib/enonic/asset');` and replace four `portal.assetUrl({...})` calls with `assetLib.assetUrl({...})`. The `portal` import is retained because `portal.getComponent`, `portal.getSiteConfig`, and `portal.componentUrl` are still used.

Parameter shape is identical to `portal.assetUrl({path: ...})`, no other call options are used.

Closes #55

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean.
- [x] App bundle reaches `ACTIVE` in a `/tmp/xp-e2e-*` XP 8 runtime (`Started application com.enonic.app.poll bundle 117`).
- [x] All four asset paths used by the migrated call sites resolve via the Site's asset API (`/site/default/master/e2e/_/com.enonic.app.poll:asset/<fp>/<path>`), each returning HTTP 200 with the correct content-type:
  - `jquery/4.0.0/jquery.min.js` → 200, `application/javascript`, 78748 B
  - `js/polls.js` → 200, `application/javascript`, 1565 B
  - `css/polls.css` → 200, `text/css`, 1018 B
  - `css/poll-bootstrap.css` → 200, `text/css`, 915 B